### PR TITLE
Updated hyper configuration filename in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Install
 
-Add `hyperterm-monokai` to the plugins list in your `~/.hyperterm.js` config file.
+Add `hyperterm-monokai` to the plugins list in your `~/.hyper.js` config file.
 
 ## License
 


### PR DESCRIPTION
The filename has changed to **`hyper.js`** and is no longer called `hyperterm.js`.