### PR TITLE
Add cursor transparency

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,6 @@ exports.decorateConfig = (config) => (
       .tab_active:before {
         border-bottom-color: #E6DB74 !important;
       }
-      ::selection { background-color: #999; }
     `
   })
 );

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ exports.decorateConfig = (config) => (
   Object.assign({}, config, {
     backgroundColor,
     foregroundColor,
-    cursorColor: foregroundColor,
+    cursorColor: 'rgba(248, 248, 240, 0.5)',
     colors,
     css: `
       ${config.css || ''}
@@ -37,6 +37,7 @@ exports.decorateConfig = (config) => (
       .tab_active:before {
         border-bottom-color: #E6DB74 !important;
       }
+      ::selection { background-color: #999; }
     `
   })
 );


### PR DESCRIPTION
Everything's in the title, but here's a little screenshot:

![image](https://cloud.githubusercontent.com/assets/15224242/23585330/e8661370-01cf-11e7-9d70-f1652f300f30.png)

(I thought we could edit the selection's color from the theme, but I was wrong, you have to add it in your config in the `termCSS` value)